### PR TITLE
Added correct shortcode

### DIFF
--- a/wp-san-esc-demo.php
+++ b/wp-san-esc-demo.php
@@ -24,7 +24,7 @@ class DataSanEscDemo
 
     public function init()
     {
-        add_shortcode('wp_san_esc_demo', array($this, 'showDemo'));
+        add_shortcode('fluent_san_esc_demo', array($this, 'showDemo'));
         add_action('wp_ajax_fluent_demo_parser', [$this, 'handleAjax']);
         add_action('wp_ajax_nopriv_fluent_demo_parser', [$this, 'handleAjax']);
     }


### PR DESCRIPTION
The shortcode in the doc was `fluent_san_esc_demo` however in the core it was implemented with `wp_san_esc_demo` shortcode.